### PR TITLE
feat: upgrade to jdk 21

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 17
+    - name: Set up JDK 21
       uses: actions/setup-java@v1
       with:
-        java-version: 17
+        java-version: 21
     - name: Set env
       run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
     - name: Add Arc release

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,10 +11,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 17
+    - name: Set up JDK 21
       uses: actions/setup-java@v1
       with:
-        java-version: 17
+        java-version: 21
     - name: Setup Gradle
       uses: gradle/gradle-build-action@v2
     - name: Run unit tests

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -21,10 +21,10 @@ jobs:
         git tag ${BNUM}
         git config --global user.name "Github Actions"
         git push https://Anuken:${{ secrets.API_TOKEN_GITHUB }}@github.com/Anuken/MindustryBuilds ${BNUM}
-    - name: Set up JDK 17
+    - name: Set up JDK 21
       uses: actions/setup-java@v1
       with:
-        java-version: 17
+        java-version: 21
     - name: Setup Gradle
       uses: gradle/gradle-build-action@v2
     - name: Update bundles

--- a/build.gradle
+++ b/build.gradle
@@ -193,7 +193,7 @@ allprojects{
 
     tasks.withType(JavaCompile){
         targetCompatibility = 8
-        sourceCompatibility = JavaVersion.VERSION_17
+        sourceCompatibility = JavaVersion.VERSION_21
         options.encoding = "UTF-8"
         options.compilerArgs += ["-Xlint:deprecation"]
         dependsOn clearCache
@@ -228,7 +228,7 @@ configure(subprojects - project(":annotations")){
     tasks.withType(Javadoc){
         options{
             addStringOption('Xdoclint:none', '-quiet')
-            addStringOption('-release', '17')
+            addStringOption('-release', '21')
             encoding('UTF-8')
         }
     }
@@ -262,7 +262,7 @@ project(":core"){
 
     kapt{
         javacOptions{
-            option("-source", "17")
+            option("-source", "21")
             option("-target", "1.8")
         }
     }

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -2,7 +2,7 @@ jdk:
   - openjdk16
 before_install:
   - wget https://github.com/sormuras/bach/raw/releases/11/install-jdk.sh
-  - source install-jdk.sh --feature 17
+  - source install-jdk.sh --feature 21
   - jshell --version
 install:
   - ./gradlew publishToMavenLocal

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,5 @@
-if(JavaVersion.current().ordinal() < JavaVersion.VERSION_17.ordinal()){
-    throw new Exception("!!! YOU MUST USE JAVA 17 OR ABOVE TO COMPILE AND RUN MINDUSTRY !!! Read the README. Your version: ${System.properties["java.version"]}")
+if(JavaVersion.current().ordinal() < JavaVersion.VERSION_21.ordinal()){
+    throw new Exception("!!! YOU MUST USE JAVA 21 OR ABOVE TO COMPILE AND RUN MINDUSTRY !!! Read the README. Your version: ${System.properties["java.version"]}")
 }
 
 include 'desktop', 'core', 'server', 'ios', 'annotations', 'tools', 'tests'


### PR DESCRIPTION
This pull request updates the Java Development Kit (JDK) version used across the project from JDK 17 to JDK 21. The changes affect workflows, build scripts, and runtime requirements.

### Workflow Updates:
* [`.github/workflows/deployment.yml`](diffhunk://#diff-5a17873aec4eae6b52b00959d8f9e17672912858f63181d39de8c3a713e90018L18-R21): Updated the JDK version from 17 to 21 in the deployment workflow.
* [`.github/workflows/pr.yml`](diffhunk://#diff-15c806aa509538190832852f439e9921a23bec2da81f95ed0e4bf13c14e5b160L14-R17): Updated the JDK version from 17 to 21 in the pull request workflow.
* [`.github/workflows/push.yml`](diffhunk://#diff-f3fc934cf0d89bdf07de358896ff90f1202585df812cf606206d1830a9949811L24-R27): Updated the JDK version from 17 to 21 in the push workflow.

### Build Script Updates:
* [`jitpack.yml`](diffhunk://#diff-1604193a5efbe3735c6ab8b44601ad6e42df52f6834bcc155650e3eef5b3fa94L5-R5): Updated the JDK version used in the build script from 17 to 21.

### Runtime Requirement Update:
* [`settings.gradle`](diffhunk://#diff-7f825392aa37acd1cee0c2e7b9bb7366ad6eac64f3e6cdd816e156bcb69d30deL1-R2): Updated the minimum required JDK version for compiling and running the project from 17 to 21. This change also updates the exception message to reflect the new requirement.

If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
