### PR TITLE
chore: updated deployment.yml

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -19,71 +19,21 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 21
-    - name: Set env
+        
+    - name: Setup Environment
       run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
-    - name: Add Arc release
-      run: |
-        git config --global user.email "actions@github.com"
-        git config --global user.name "Github Actions"
-        git clone --depth=1 --branch=master https://github.com/Anuken/Arc ../Arc
-        cd ../Arc
-        git tag ${RELEASE_VERSION}
-        git push https://Anuken:${{ secrets.API_TOKEN_GITHUB }}@github.com/Anuken/Arc ${RELEASE_VERSION};
-        cd ../Mindustry
-    - name: Update JITpack repo
-      run: |
-        cd ../
-        cp -r ./Mindustry ./MindustryJitpack
-        cd MindustryJitpack
-        git config --global user.name "Github Actions"
-        git config --global user.email "actions@github.com"
-        git clone --depth 1 https://github.com/Anuken/MindustryJitpack.git
-        rm -rf .git
-        cp -r ./MindustryJitpack/.git ./.git
-        rm -rf MindustryJitpack
-        rm -rf .github
-        rm README.md
-        git add .
-        git commit --allow-empty -m "Updating"
-        git push https://Anuken:${{ secrets.API_TOKEN_GITHUB }}@github.com/Anuken/MindustryJitpack
-        git tag ${RELEASE_VERSION}
-        git push https://Anuken:${{ secrets.API_TOKEN_GITHUB }}@github.com/Anuken/MindustryJitpack
-        cd ../Mindustry
+      
     - name: Create artifacts
       run: |
         ./gradlew desktop:dist server:dist core:mergedJavadoc -Pbuildversion=${RELEASE_VERSION:1}
-    - name: Update docs
-      run: |
-        cd ../
-        git config --global user.email "cli@github.com"
-        git config --global user.name "Github Actions"
-        git clone --depth=1 https://github.com/MindustryGame/docs.git
-        cd docs
-        find . -maxdepth 1 ! -name ".git" ! -name . -exec rm -r {} \;
-        cd ../
-        cp -a Mindustry/core/build/javadoc/. docs/
-        cd docs
-        git add .
-        git commit --allow-empty -m "Update ${RELEASE_VERSION:1}"
-        git push https://Anuken:${{ secrets.API_TOKEN_GITHUB }}@github.com/MindustryGame/docs
-        cd ../Mindustry
-    - name: Update F-Droid build string
-      run: |
-        git clone --depth=1 --branch=master https://github.com/Anuken/MindustryBuilds ../MindustryBuilds
-        cd ../MindustryBuilds
-        echo "Updating version to ${RELEASE_VERSION:1}"
-        BNUM=$(($GITHUB_RUN_NUMBER + 1000))
-        echo versionName=8-fdroid-${RELEASE_VERSION:1}$'\n'versionCode=${BNUM} > version_fdroid.txt
-        git add .
-        git commit -m "Updating to build ${RELEASE_VERSION:1}"
-        git push https://Anuken:${{ secrets.API_TOKEN_GITHUB }}@github.com/Anuken/MindustryBuilds
-        cd ../Mindustry
+        
     - name: Upload client artifacts
       uses: svenstaro/upload-release-action@v2
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
         file: desktop/build/libs/Mindustry.jar
         tag: ${{ github.ref }}
+        
     - name: Upload server artifacts
       uses: svenstaro/upload-release-action@v2
       with:


### PR DESCRIPTION
This pull request simplifies the deployment workflow in `.github/workflows/deployment.yml` by removing several steps related to auxiliary repository updates and focusing on core artifact creation and upload tasks. The most important changes are grouped below:

### Workflow Simplification:

* Removed steps for tagging and pushing releases to the `Arc` repository, as well as updating the JITpack repository (`MindustryJitpack`). These steps are no longer part of the workflow.
* Eliminated the process for updating documentation in the `docs` repository, including cloning, replacing files, and pushing updates.
* Removed the step for updating the F-Droid build string in the `MindustryBuilds` repository. This includes updating version information and committing changes.

### Minor Adjustments:

* Renamed the "Set env" step to "Setup Environment" for clarity.
If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:
- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
