### PR TITLE
updated docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,14 +16,18 @@ services:
 
   mindustry-client:
     build: .
+    # WSLg configuration
     environment:
-      - DISPLAY=host.docker.internal:0.0
+      - DISPLAY=${DISPLAY}
+      - WAYLAND_DISPLAY=${WAYLAND_DISPLAY}
+      - PULSE_SERVER=${PULSE_SERVER}
+      - XDG_RUNTIME_DIR=${XDG_RUNTIME_DIR}
+      - HOME=/home/mindustry
     volumes:
-      - client-data:/root/.local/share/Mindustry
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
+      - /mnt/wslg:/mnt/wslg
+      - /mnt/wslg/.X11-unix:/tmp/.X11-unix
+      - ~/.mindustry_data:/home/mindustry
 
 volumes:
   server-data:
   server-maps:
-  client-data:


### PR DESCRIPTION
This pull request updates the `docker-compose.yml` file to improve compatibility with WSLg (Windows Subsystem for Linux GUI). The most significant changes involve updating environment variables and volume mappings for the `mindustry-client` service.

### Updates for WSLg compatibility:
* Updated environment variables for `mindustry-client` to use dynamic values (`${DISPLAY}`, `${WAYLAND_DISPLAY}`, `${PULSE_SERVER}`, `${XDG_RUNTIME_DIR}`) and set the `HOME` directory to `/home/mindustry`. This ensures the application works seamlessly with WSLg.
* Modified volume mappings for `mindustry-client` to include WSLg-specific paths (`/mnt/wslg` and `/mnt/wslg/.X11-unix`) and redirect user data to `~/.mindustry_data` instead of `client-data`.

### Removed legacy configurations:
* Removed the `extra_hosts` setting (`"host.docker.internal:host-gateway"`) and the `client-data` volume, as they are no longer needed with the updated WSLg setup.
If your pull request is **not** translation or serverlist-related, read the list of requirements below and check each box:

- [x] I have read the [contribution guidelines](https://github.com/Anuken/Mindustry/blob/master/CONTRIBUTING.md).
- [x] I have ensured that my code compiles, if applicable.
- [x] I have ensured that any new features in this PR function correctly in-game, if applicable.
